### PR TITLE
fix the concatination section of vrs signature parts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name="nobi-filecoin-lotus",
-    version="1.2.3", # forked_version -> "1.2.1",
+    version="1.2.4", # forked_version -> "1.2.1",
     author="Wen",
     author_email="wenqinchao@gmail.com",
     description="A package interact with bitcoin node",

--- a/src/filecoin_lotus/utils/transaction.py
+++ b/src/filecoin_lotus/utils/transaction.py
@@ -43,13 +43,10 @@ def get_signature(sign_hex, unsign_hex, pubkey):
 
 
 def handle_vrs(v, r, s):
-    r_hex = hex(r)[2:]
-    s_hex = hex(s)[2:]
-    r_hex_h = r_hex + "0" if len(r_hex) != 64 else r_hex
-    s_hex_h = "0" + s_hex if len(s_hex) != 64 else s_hex
-    r_s_hex = r_hex_h + s_hex_h
+    r_hex = hex(r)[2:].rjust(64, "0")
+    s_hex = hex(s)[2:].rjust(64, "0")
     v_hex = '0' + str(v - 27)
-    return r_s_hex + v_hex
+    return r_hex + s_hex + v_hex
 
 
 class FilTransaction:


### PR DESCRIPTION
Fix on the number of zero paddings on `r` and `s` sections of the signature and also the direction of zero paddings on `r` section of the signature.
Have done calibration testnet transaction with a signature containing `r` section starting with zero to test the newly fixed functionality:

tx hash: [bafy2bzacedaobqrv4tjlkkmnhi7mygoyexozalxuhlxtmmjjaadrgkd272d2m](https://calibration.filfox.info/en/message/bafy2bzacedaobqrv4tjlkkmnhi7mygoyexozalxuhlxtmmjjaadrgkd272d2m?t=1)

```
r: 03c4e322c45cfd4692601a2a4d60829f86e9a6db6415c8b6244be9e36671703d
s: 307759715c2e004f2f02c93522f4d2cb303394e507b372f446a4bb231e1851eb
v: 00
[2024-03-11 21:39:54]: 66290 DEBUG Filecoin transaction signed successfully.
```
